### PR TITLE
No longer rely on the presence of bash

### DIFF
--- a/Installer-Linux/linux-hosts-installer.sh
+++ b/Installer-Linux/linux-hosts-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux hosts Installer for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-hosts-uninstaller.sh
+++ b/Installer-Linux/linux-hosts-uninstaller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux hosts UnInstaller for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-hosts-updater.sh
+++ b/Installer-Linux/linux-hosts-updater.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux hosts Updater for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-hosts.deny-installer.sh
+++ b/Installer-Linux/linux-hosts.deny-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux hosts.deny Installer for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-hosts.deny-uninstaller.sh
+++ b/Installer-Linux/linux-hosts.deny-uninstaller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux hosts.deny UnInstaller for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-hosts.deny-updater.sh
+++ b/Installer-Linux/linux-hosts.deny-updater.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux hosts.deny Updater for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-superhosts.deny-installer.sh
+++ b/Installer-Linux/linux-superhosts.deny-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux superhosts.deny Installer for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-superhosts.deny-uninstaller.sh
+++ b/Installer-Linux/linux-superhosts.deny-uninstaller.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux superhosts.deny UnInstaller for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist

--- a/Installer-Linux/linux-superhosts.deny-updater.sh
+++ b/Installer-Linux/linux-superhosts.deny-updater.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Linux superhosts.deny Updater for the Ultimate Hosts Blacklist
 # Repo Url: https://github.com/Ultimate-Hosts-Blacklist/Ultimate.Hosts.Blacklist


### PR DESCRIPTION
Although bash is available in most distributions, this is not always the case.
A notable example are docker containers based on Alpine linux it's more often missing than present.
This PR makes sure it works everywhere by relying on **a** shell instead of **a specific** shell.

The FHS defines that if the system has shells (1 or more), at least one of them should be in `/bin`. So the forced location is not a problem.

The script itself doesn't need any change, it always does exactly the same. It doesn't matter if you use bash, zsh, csh or even busybox.