### PR TITLE
Accounts for a root-user with a different name

### DIFF
--- a/Installer-Linux/linux-hosts-installer.sh
+++ b/Installer-Linux/linux-hosts-installer.sh
@@ -9,7 +9,7 @@
 #
 # root has to run the script
 #
-if [[ $(id -u) != 0 ]]
+if [ $(id -u) != 0 ]
     then
     printf "You need to be root to do this!\nIf you have SUDO installed, then run this script with `sudo ${0}`"
     exit 1

--- a/Installer-Linux/linux-hosts-installer.sh
+++ b/Installer-Linux/linux-hosts-installer.sh
@@ -9,7 +9,7 @@
 #
 # root has to run the script
 #
-if [[ $(id -u -n) != "root" ]]
+if [[ $(id -u) != 0 ]]
     then
     printf "You need to be root to do this!\nIf you have SUDO installed, then run this script with `sudo ${0}`"
     exit 1


### PR DESCRIPTION
Purely in theory, the root user can have another name but he will always have the UID 0.
Although I have never seen this is in real life, this PR solve this 'problem".

It's also a couple of milliseconds faster because `id` is not forced to look up a name. (Even when asking for a name it will always look up the UID first)