### PR TITLE
No square brackets

### DIFF
--- a/Installer-Linux/linux-hosts-installer.sh
+++ b/Installer-Linux/linux-hosts-installer.sh
@@ -9,11 +9,7 @@
 #
 # root has to run the script
 #
-if [[ $(id -u) != 0 ]]
-    then
-    printf "You need to be root to do this!\nIf you have SUDO installed, then run this script with `sudo ${0}`"
-    exit 1
-fi
+test $(id -u) -ne 0 && printf "You need to be root to do this!\nIf you have SUDO installed, then run this script with `sudo ${0}`" && exit 1
 
 # First Backup Existing hosts file
 sudo mv /etc/hosts /etc/hosts.bak

--- a/Installer-Linux/linux-hosts-installer.sh
+++ b/Installer-Linux/linux-hosts-installer.sh
@@ -9,7 +9,7 @@
 #
 # root has to run the script
 #
-if [[ $(id -u -n) != "root" ]]
+if [[ $(id -u) != 0 ]]
     then
     printf "You need to be root to do this!\nIf you have SUDO installed, then run this script with `sudo ${0}`"
     exit 1


### PR DESCRIPTION
This PR has the same effect as my previous PR ( #606 ).

The difference: It uses `test something ` to check conditions instead of `if [[ something ]] ; then ... ; fi`

Although this is my own PR, I actually _don't_ like it.

It's safe to assume a system where the shell does not support `[[ ]]` is equally as rare as a system where a `test` shell-builtin and/or binary isn't available. But the one with the square brackets is more clear so I suggest closing this one and merging #606.

The only reason I opened this PR is because of rusty-snake's comment in #605