### PR TITLE
Try harder to become root and speed up by skipping unnecessary sudo's

### DIFF
--- a/Installer-Linux/linux-hosts-installer.sh
+++ b/Installer-Linux/linux-hosts-installer.sh
@@ -6,19 +6,33 @@
 # Copyright (c) 2017, 2018, 2019, 2020 Mitchell Krog - @mitchellkrogza
 # Copyright (c) 2017, 2018, 2019, 2020 Nissar Chababy - @funilrys
 
-#
-# root has to run the script
-#
-if [[ $(id -u -n) != "root" ]]
-    then
-    printf "You need to be root to do this!\nIf you have SUDO installed, then run this script with `sudo ${0}`"
-    exit 1
+
+if [ $(id -u) -eq 0 ] ; then
+    # The 'real' script:
+    # First Backup Existing hosts file
+    mv /etc/hosts /etc/hosts.bak
+    # Now download the new hosts file and put it into place
+    wget https://hosts.ubuntu101.co.za/hosts -O /etc/hosts
+    exit 0
+else
+    # Multiple tricks to run this script as root before running the real script
+    echo "This script needs to be ran as root, let's switch to root:"
+    sudo=$(which sudo)
+    if [ ! -z $sudo ] ; then
+        $sudo $0 && exit 0
+        echo "Something went wrong with trying to use 'sudo' to run this script"
+        exit 1
+    else
+        echo "I can't find 'sudo', I'll try to use 'su' to become root."
+        echo "(Remember that 'su' is deprecated, I strongly recommend installing 'sudo'.)"
+        su=$(which su)
+        if [ ! -z $su ] ; then
+            $su -c $0 && exit 0
+            echo "Something went wrong with trying to use 'su' to run this script"
+            exit 1
+        else
+            echo "I also can't find 'su', you'll need to find another way to become root..."
+            exit 1
+        fi
+    fi
 fi
-
-# First Backup Existing hosts file
-sudo mv /etc/hosts /etc/hosts.bak
-
-# Now download the new hosts file and put it into place
-sudo wget https://hosts.ubuntu101.co.za/hosts -O /etc/hosts
-
-exit 0


### PR DESCRIPTION
_All other scripts in `Installer-Linux` can be improved in the same way as below, but I'm not spending time on it if this doesn't get merged..._

This PR:
- Speeds up the script because you don't need to run `sudo` anymore if you are already root
- Tries harder to run itself as root if this is not the case:
  - It checks where `sudo` is located instead of assuming it is in `$PATH` (it uses `which` instead of `env` for this because `env` is a binary that isn't necessarily available. `which` on the other hand is also a shell-buildin that even shells as tiny as busybox have)
  - It tries to use `su` if you don't have `sudo` and warns you that this is deprecated (also not assuming it's in `$PATH`)
  - It quits and warns you that you'll have to become root manually if both sudo and su aren't available
  - It gives the correct reason if something fails*
  - Doesn't depend on the name of root (see #606 for more info)

*The 'real' part of the script hasn't been improved yet, that's for another PR. So if one these commands fail you will obviously not see the correct reason yet

- This PR conflicts with #606 . Use that one if you want something easy and this one if you want something good.
- This PR has been tested with multiple shells, including tiny ones, so it can be combined with #605