### PR TITLE
👷 use latest major version for actions/checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Clone repository
         with:
           token: "${{ secrets.BOT_REPO_PAT }}"

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -22,7 +22,7 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Clone repository
         with:
           token: "${{ secrets.BOT_REPO_PAT }}"


### PR DESCRIPTION
Use latest major version of [actions/checkout](https://github.com/actions/checkout) for GitHub Actions.